### PR TITLE
Support get_bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ pub mod tools;
 mod util;
 mod valid;
 
-use path::*;
+use path::Path;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
 use util::{pmatch, tostr, unescape};
@@ -40,7 +41,7 @@ impl PartialOrd for Kind {
 
 impl PartialEq for Kind {
     fn eq(&self, other: &Self) -> bool {
-        self.cmp(&other) == Ordering::Equal
+        self.cmp(other) == Ordering::Equal
     }
 }
 
@@ -79,8 +80,7 @@ static KINDMAP: [Kind; 256] = {
 
 /// Value is the JSON value returned from the `get` function.
 pub struct Value<'a> {
-    slice: &'a str,
-    owned: String,
+    data: Cow<'a, str>,
     uescstr: String,
     info: InfoBits,
     index: Option<usize>,
@@ -96,7 +96,7 @@ impl<'a> PartialOrd for Value<'a> {
 
 impl<'a> PartialEq for Value<'a> {
     fn eq(&self, other: &Self) -> bool {
-        self.cmp(&other) == Ordering::Equal
+        self.cmp(other) == Ordering::Equal
     }
 }
 
@@ -118,7 +118,7 @@ impl<'a> Ord for Value<'a> {
                 Ordering::Equal
             }
         } else {
-            self.json().cmp(other.json())
+            self.data.cmp(&other.data)
         }
     }
 }
@@ -126,8 +126,7 @@ impl<'a> Ord for Value<'a> {
 impl<'a> Default for Value<'a> {
     fn default() -> Self {
         return Value {
-            slice: "",
-            owned: String::default(),
+            data: Cow::Owned(String::default()),
             uescstr: String::default(),
             info: 0,
             index: None,
@@ -143,9 +142,8 @@ impl<'a> fmt::Display for Value<'a> {
 
 fn json_clone_from_ref<'a>(json: &'a Value<'a>) -> Value<'a> {
     Value {
-        slice: json.json(),
-        owned: String::new(),
-        uescstr: json.uescstr.to_owned(),
+        data: json.data.clone(),
+        uescstr: json.uescstr.clone(),
         info: json.info,
         index: json.index,
     }
@@ -153,42 +151,36 @@ fn json_clone_from_ref<'a>(json: &'a Value<'a>) -> Value<'a> {
 
 fn json_from_slice<'a>(slice: &'a [u8], index: Option<usize>, info: InfoBits) -> Value<'a> {
     let mut json = Value {
-        slice: tostr(slice),
-        owned: String::new(),
+        data: Cow::Borrowed(tostr(slice)),
         uescstr: String::new(),
         info,
         index,
     };
     json_unescape_string(&mut json);
-    return json;
+    json
 }
 
 fn json_from_owned<'a>(owned: String, index: Option<usize>, info: InfoBits) -> Value<'a> {
     let mut json = Value {
-        slice: "",
-        owned: owned,
+        data: Cow::Owned(owned),
         uescstr: String::new(),
         info,
         index,
     };
     json_unescape_string(&mut json);
-    return json;
+    json
 }
 
 fn json_unescape_string<'a>(json: &mut Value<'a>) {
     if json.info & (INFO_STRING | INFO_ESC) == (INFO_STRING | INFO_ESC) {
         // Escaped string. We must unescape it into a new allocated string.
-        json.uescstr = unescape(json.json());
+        json.uescstr = unescape(&json.data);
     }
 }
 
 impl<'a> Value<'a> {
     pub fn get(&'a self, path: &'a str) -> Value<'a> {
-        let mut json = if self.slice.len() > 0 {
-            get(&self.slice, path)
-        } else {
-            json_into_owned(get(&self.owned, path))
-        };
+        let mut json = get(&self.data, path);
         let mut index = None;
         if let Some(index1) = self.index {
             if let Some(index2) = json.index {
@@ -200,23 +192,15 @@ impl<'a> Value<'a> {
     }
 
     pub fn exists(&self) -> bool {
-        self.json().len() > 0
+        self.data.len() > 0
     }
 
     pub fn kind(&self) -> Kind {
         KINDMAP[(self.info << 24 >> 24) as usize]
     }
 
-    pub fn json(&self) -> &str {
-        if self.owned.len() > 0 {
-            self.owned.as_str()
-        } else {
-            self.slice
-        }
-    }
-
     pub fn f64(&'a self) -> f64 {
-        let raw = self.json().as_bytes();
+        let raw = self.data.as_bytes();
         match self.kind() {
             Kind::True => 1.0,
             Kind::String => {
@@ -236,7 +220,7 @@ impl<'a> Value<'a> {
     }
 
     pub fn i64(&'a self) -> i64 {
-        let raw = self.json().as_bytes();
+        let raw = self.data.as_bytes();
         match self.kind() {
             Kind::True => 1,
             Kind::String => {
@@ -252,7 +236,7 @@ impl<'a> Value<'a> {
     }
 
     pub fn u64(&'a self) -> u64 {
-        let raw = self.json().as_bytes();
+        let raw = self.data.as_bytes();
         match self.kind() {
             Kind::True => 1,
             Kind::String => {
@@ -280,52 +264,60 @@ impl<'a> Value<'a> {
 
     pub fn i16(&'a self) -> i16 {
         let x = self.i64();
-        (if x < -32768 {
+        if x < -32768 {
             -32768
         } else if x > 32767 {
             32767
         } else {
-            x
-        }) as i16
+            x as i16
+        }
     }
 
     pub fn i8(&'a self) -> i8 {
         let x = self.i64();
-        (if x < -128 {
+        if x < -128 {
             -128
         } else if x > 127 {
             127
         } else {
-            x
-        }) as i8
+            x as i8
+        }
     }
 
     pub fn u32(&'a self) -> u32 {
         let x = self.u64();
-        (if x > 4294967295 { 4294967295 } else { x }) as u32
+        if x > 4294967295 {
+            4294967295
+        } else {
+            x as u32
+        }
     }
 
     pub fn u16(&'a self) -> u16 {
         let x = self.u64();
-        (if x > 65535 { 65535 } else { x }) as u16
+        if x > 65535 {
+            65535
+        } else {
+            x as u16
+        }
     }
 
     pub fn u8(&'a self) -> u8 {
         let x = self.u64();
-        (if x > 255 { 255 } else { x }) as u8
+        if x > 255 {
+            255
+        } else {
+            x as u8
+        }
     }
 
     pub fn bool(&'a self) -> bool {
-        let raw = self.json();
+        let raw = self.data.as_ref();
         match raw {
-            r#"1"# | r#"true"# => true,
-            r#"0"# | r#"false"# => false,
-
-            r#""t""# | r#""1""# | r#""T""# => true,
-            r#""f""# | r#""0""# | r#""F""# => false,
-
-            r#""true""# | r#""TRUE""# | r#""True""# => true,
-            r#""false""# | r#""FALSE""# | r#""False""# => false,
+            r#"1"# | r#"true"# | r#""t""# | r#""1""# | r#""T""# | r#""true""# | r#""TRUE""#
+            | r#""True""# => true,
+            r#"0"# | r#"false"# | r#""f""# | r#""0""# | r#""F""# | r#""false""# | r#""FALSE""#
+            | r#""False""# => false,
             _ => self.i64() != 0,
         }
     }
@@ -334,12 +326,12 @@ impl<'a> Value<'a> {
         match self.kind() {
             Kind::True => "true",
             Kind::False => "false",
-            Kind::Object | Kind::Array | Kind::Number => self.json(),
+            Kind::Object | Kind::Array | Kind::Number => &self.data,
             Kind::String => {
                 if self.info & INFO_ESC == INFO_ESC {
                     self.uescstr.as_ref()
                 } else {
-                    let raw = self.json().as_bytes();
+                    let raw = self.data.as_bytes();
                     tostr(&raw[1..raw.len() - 1])
                 }
             }
@@ -355,10 +347,10 @@ impl<'a> Value<'a> {
         }
         let kind = self.kind();
         if kind != Kind::Object && kind != Kind::Array {
-            iter(Value::default(), json_clone_from_ref(&self));
+            iter(Value::default(), json_clone_from_ref(self));
             return;
         }
-        let json = self.json().as_bytes();
+        let json = self.data.as_bytes();
         for_each(json, 0, false, kind, iter);
     }
 
@@ -368,7 +360,7 @@ impl<'a> Value<'a> {
             self.each(|_, value| {
                 arr.push(value);
                 true
-            })
+            });
         }
         arr
     }
@@ -410,10 +402,8 @@ fn for_each<'a>(
                         break;
                     }
                 }
-            } else {
-                if !iter(Value::default(), res) {
-                    break;
-                }
+            } else if !iter(Value::default(), res) {
+                break;
             }
             index += 1;
         }
@@ -506,15 +496,14 @@ fn scan_string<'a>(json: &'a [u8], mut i: usize) -> (&'a [u8], InfoBits, usize) 
         if ch as u8 == b'"' {
             i += 1;
             return (&json[s..i], info, i);
-        } else {
-            // must be a escape character '\'
-            info |= INFO_ESC;
-            i += 1;
-            if i == json.len() {
-                break;
-            }
-            i += 1;
         }
+        // must be a escape character '\'
+        info |= INFO_ESC;
+        i += 1;
+        if i == json.len() {
+            break;
+        }
+        i += 1;
     }
     ("".as_bytes(), 0, json.len())
 }
@@ -608,7 +597,7 @@ fn proc_value<'a>(
                 } else {
                     INFO_ARRAY
                 };
-                return (json_from_slice(val, Some(s), 0 | kind), i, path);
+                return (json_from_slice(val, Some(s), kind), i, path);
             }
         } else {
             i = scan_squash(json, i).1;
@@ -729,7 +718,7 @@ fn get_arr<'a>(
     // value2
     // value3
     // ```
-    if path.comp.len() > 0 && path.comp[0] == b'#' {
+    if !path.comp.is_empty() && path.comp[0] == b'#' {
         if path.comp.len() == 1 {
             if path.sep == b'.' {
                 get_arr_children_with_subpath(json, i, lines, path)
@@ -806,23 +795,23 @@ fn query_matches<'a>(valin: &Value<'a>, op: &str, rpv: &str) -> bool {
     }
     let mut value = valin;
     let mut tvalue = Value::default();
-	if rpv.len() > 0 && rpv[0] == b'~' {
-		// convert to bool
-		rpv = &rpv[1..];
-		if value.bool() {
-            tvalue.slice = "true";
+    if !rpv.is_empty() && rpv[0] == b'~' {
+        // convert to bool
+        rpv = &rpv[1..];
+        if value.bool() {
+            tvalue.data = Cow::Borrowed("true");
             tvalue.info = INFO_TRUE;
-		} else {
-            tvalue.slice = "false";
-			tvalue.info = INFO_FALSE;
-		}
+        } else {
+            tvalue.data = Cow::Borrowed("false");
+            tvalue.info = INFO_FALSE;
+        }
         value = &tvalue;
-	}
+    }
     let rpv = tostr(rpv);
     if !value.exists() {
         return false;
     }
-    if op == "" {
+    if op.is_empty() {
         // the query is only looking for existence, such as:
         //   friends.#(name)
         // which makes sure that the array "friends" has an element of
@@ -880,10 +869,10 @@ fn get_arr_child_with_query<'a>(
     let (lh, op, rhv) = path.query_parts();
     let mut res = Value::default();
     i = for_each(json, i, lines, Kind::Array, |_, value| {
-        let is_match = if lh != "" {
-            query_matches(&value.get(lh), op, rhv)
-        } else {
+        let is_match = if lh.is_empty() {
             query_matches(&value, op, rhv)
+        } else {
+            query_matches(&value.get(lh), op, rhv)
         };
         if is_match {
             res = value;
@@ -911,14 +900,13 @@ fn get_arr_children_with_query_subpath<'a>(
         subpath = Some(r.0);
     }
     path = r.1;
-    let mut res = Vec::new();
-    res.push(b'[');
+    let mut res = vec![b'['];
     let mut index = 0;
     i = for_each(json, i, lines, Kind::Array, |_, value| {
-        let is_match = if lh != "" {
-            query_matches(&value.get(lh), op, rhv)
-        } else {
+        let is_match = if lh.is_empty() {
             query_matches(&value, op, rhv)
+        } else {
+            query_matches(&value.get(lh), op, rhv)
         };
         if is_match {
             let value = if let Some(subpath) = subpath {
@@ -930,7 +918,7 @@ fn get_arr_children_with_query_subpath<'a>(
                 if index > 0 {
                     res.push(b',');
                 }
-                res.extend(value.json().as_bytes());
+                res.extend(value.data.as_bytes());
                 index += 1;
             }
         }
@@ -955,8 +943,7 @@ fn get_arr_children_with_subpath<'a>(
     let r = path.next_group();
     let subpath = r.0;
     path = r.1;
-    let mut res = Vec::new();
-    res.push(b'[');
+    let mut res = vec![b'['];
     let mut index = 0;
     i = for_each(json, i, lines, Kind::Array, |_, value| {
         let value = value.get(subpath);
@@ -964,7 +951,7 @@ fn get_arr_children_with_subpath<'a>(
             if index > 0 {
                 res.push(b',');
             }
-            res.extend(value.json().as_bytes());
+            res.extend(value.data.as_bytes());
             index += 1;
         }
         true
@@ -989,7 +976,7 @@ fn get_arr_children_with_subpath<'a>(
 /// To get the number of elements in an array or to access a child path, use
 /// the '#' character.
 /// The dot and wildcard character can be escaped with '\'.
-/// 
+///
 /// ```json
 /// {
 ///   "name": {"first": "Tom", "last": "Anderson"},
@@ -1001,7 +988,7 @@ fn get_arr_children_with_subpath<'a>(
 ///   ]
 /// }
 /// ```
-/// 
+///
 /// ```json
 ///  "name.last"          >> "Anderson"
 ///  "age"                >> 37
@@ -1012,7 +999,7 @@ fn get_arr_children_with_subpath<'a>(
 ///  "c?ildren.0"         >> "Sara"
 ///  "friends.#.first"    >> ["James","Roger"]
 /// ```
-/// 
+///
 /// This function expects that the json is valid, and does not validate.
 /// Invalid json will not panic, but it may return back unexpected results.
 /// If you are consuming JSON from an unpredictable source then you may want to
@@ -1061,11 +1048,7 @@ pub fn get<'a>(json: &'a str, path: &'a str) -> Value<'a> {
         return res;
     }
     let path = tostr(path.extra);
-    let mut json = if res.slice.len() > 0 {
-        get(&res.slice, path)
-    } else {
-        json_into_owned(get(&res.owned, path))
-    };
+    let mut json = get(&res.data, path);
     let mut index = None;
     if let Some(index1) = res.index {
         if let Some(index2) = json.index {
@@ -1073,17 +1056,12 @@ pub fn get<'a>(json: &'a str, path: &'a str) -> Value<'a> {
         }
     }
     json.index = index;
-    json
+    json_into_owned(json)
 }
 
 fn json_into_owned<'a>(json: Value) -> Value<'a> {
     Value {
-        slice: "",
-        owned: if json.slice.len() > 0 {
-            json.slice.to_owned()
-        } else {
-            json.owned
-        },
+        data: Cow::Owned(json.data.into_owned()),
         uescstr: json.uescstr,
         info: json.info,
         index: json.index,
@@ -1107,11 +1085,11 @@ pub fn parse<'a>(json: &'a str) -> Value<'a> {
         match json[i] {
             b'{' => return json_from_slice(&json[i..], Some(i), INFO_OBJECT | INFO_FOG),
             b'[' => return json_from_slice(&json[i..], Some(i), INFO_ARRAY | INFO_FOG),
-            b't' | b'f' | b'n' | b'"' | b'0' | b'1' | b'2' => {}
-            b'3' | b'4' | b'5' | b'6' | b'7' | b'8' | b'9' | b'-' => {}
+            b't' | b'f' | b'n' | b'"' | b'0' | b'1' | b'2' | b'3' | b'4' | b'5' | b'6' | b'7'
+            | b'8' | b'9' | b'-' => {}
             _ => break,
         }
         return proc_value(json, i, Path::default(), true).0;
     }
-    return Value::default();
+    Value::default()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ fn json_from_owned<'a>(owned: Vec<u8>, index: Option<usize>, info: InfoBits) -> 
 
 impl<'a> Value<'a> {
     pub fn get(&'a self, path: &'a str) -> Value<'a> {
-        let mut json = get_bytes(&self.data, path);
+        let mut json = unsafe { get_bytes(&self.data, path) };
         let mut index = None;
         if let Some(index1) = self.index {
             if let Some(index2) = json.index {
@@ -981,7 +981,7 @@ fn get_arr_children_with_subpath<'a>(
 /// If you are consuming JSON from an unpredictable source then you may want to
 /// use the `valid` function first.
 pub fn get<'a>(json: &'a str, path: &'a str) -> Value<'a> {
-    get_bytes(json.as_bytes(), path)
+    unsafe { get_bytes(json.as_bytes(), path) }
 }
 
 /// Searches json for the specified path.
@@ -1022,7 +1022,7 @@ pub fn get<'a>(json: &'a str, path: &'a str) -> Value<'a> {
 /// Invalid json will not panic, but it may return back unexpected results.
 /// If you are consuming JSON from an unpredictable source then you may want to
 /// use the `valid` function first.
-pub fn get_bytes<'a>(json: &'a [u8], path: &'a str) -> Value<'a> {
+pub unsafe fn get_bytes<'a>(json: &'a [u8], path: &'a str) -> Value<'a> {
     let mut path = path;
     let mut lines = false;
     if path.len() >= 2 && path.as_bytes()[0] == b'.' && path.as_bytes()[1] == b'.' {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ fn json_from_owned<'a>(owned: String, index: Option<usize>, info: InfoBits) -> V
 fn json_unescape_string<'a>(json: &mut Value<'a>) {
     if json.info & (INFO_STRING | INFO_ESC) == (INFO_STRING | INFO_ESC) {
         // Escaped string. We must unescape it into a new allocated string.
-        json.uescstr = unescape(&json.data);
+        json.uescstr = unescape(&json.data.as_bytes());
     }
 }
 
@@ -205,7 +205,7 @@ impl<'a> Value<'a> {
             Kind::True => 1.0,
             Kind::String => {
                 if self.info & INFO_ESC == INFO_ESC {
-                    raw_to_f64(&unescape(tostr(raw)))
+                    raw_to_f64(&unescape(raw))
                 } else {
                     raw_to_f64(tostr(&raw[1..raw.len() - 1]))
                 }
@@ -225,7 +225,7 @@ impl<'a> Value<'a> {
             Kind::True => 1,
             Kind::String => {
                 if self.info & INFO_ESC == INFO_ESC {
-                    raw_to_i64(&unescape(tostr(raw)))
+                    raw_to_i64(&unescape(raw))
                 } else {
                     raw_to_i64(tostr(&raw[1..raw.len() - 1]))
                 }
@@ -241,7 +241,7 @@ impl<'a> Value<'a> {
             Kind::True => 1,
             Kind::String => {
                 if self.info & INFO_ESC == INFO_ESC {
-                    raw_to_u64(&unescape(tostr(raw)))
+                    raw_to_u64(&unescape(raw))
                 } else {
                     raw_to_u64(tostr(&raw[1..raw.len() - 1]))
                 }
@@ -681,7 +681,7 @@ fn get_obj<'a>(json: &'a [u8], mut i: usize, path: Path<'a>) -> (Value<'a>, usiz
 fn key_match(key: &[u8], info: InfoBits, path: &Path) -> bool {
     let comp = tostr(path.comp);
     if info & INFO_ESC == INFO_ESC {
-        let key = unescape(tostr(key));
+        let key = unescape(key);
         if path.pat || path.esc {
             pmatch(comp, key)
         } else {
@@ -784,7 +784,7 @@ fn query_matches<'a>(valin: &Value<'a>, op: &str, rpv: &str) -> bool {
         for c in rpv {
             if *c == b'\\' {
                 overwrite = true;
-                uesc_str = unescape(tostr(rpv));
+                uesc_str = unescape(rpv);
                 rpv = uesc_str.as_bytes();
                 break;
             }

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -53,7 +53,7 @@ fn mod_valid(json: &str, _: &str) -> String {
 }
 
 fn mod_pretty(json: &str, arg: &str) -> String {
-    if arg.len() > 0 {
+    if !arg.is_empty() {
         let mut opts = pretty::PrettyOptions::new();
         let indent = super::get(arg, "indent");
         let prefix = super::get(arg, "prefix");
@@ -83,7 +83,7 @@ fn mod_ugly(json: &str, _: &str) -> String {
 
 fn mod_reverse(json: &str, _: &str) -> String {
     let res = parse(json);
-    let json = res.slice.as_bytes();
+    let json = res.data.as_bytes();
     let mut slices = Vec::new();
     let endcaps;
     let mut cap = 2;
@@ -93,20 +93,20 @@ fn mod_reverse(json: &str, _: &str) -> String {
             res.each(|key, value| {
                 let kindex = key.index.unwrap();
                 let vindex = value.index.unwrap();
-                let slice = &json[kindex..vindex + value.slice.len()];
+                let slice = &json[kindex..vindex + value.data.len()];
                 slices.push(slice);
                 cap += 1 + slice.len();
-                return true;
+                true
             });
         }
         Kind::Array => {
             endcaps = (b'[', b']');
             res.each(|_, value| {
                 let vindex = value.index.unwrap();
-                let slice = &json[vindex..vindex + value.slice.len()];
+                let slice = &json[vindex..vindex + value.data.len()];
                 slices.push(slice);
                 cap += 1 + slice.len();
-                return true;
+                true
             });
         }
         _ => return tostr(json).to_owned(),
@@ -130,8 +130,7 @@ fn mod_join(json: &str, arg: &str) -> String {
         return json.to_owned();
     }
     let preserve = get(arg, "preserve").bool();
-    let mut out = Vec::new();
-    out.push(b'{');
+    let mut out = vec![b'{'];
     if preserve {
         // Preserve duplicate keys.
         let mut idx = 0;
@@ -142,10 +141,10 @@ fn mod_join(json: &str, arg: &str) -> String {
             if idx > 0 {
                 out.push(b',');
             }
-            out.extend(unwrap(value.slice.as_bytes()));
+            out.extend(unwrap(value.data.as_bytes()));
             idx += 1;
-            return true;
-        })
+            true
+        });
     } else {
         // Deduplicate keys and generate an object with stable ordering.
         let mut keys = Vec::new();
@@ -157,13 +156,13 @@ fn mod_join(json: &str, arg: &str) -> String {
             value.each(|key, value| {
                 let k = key.str().as_bytes().to_owned();
                 if !kvals.contains_key(&k) {
-                    let key = key.json().as_bytes().to_owned();
+                    let key = key.data.as_bytes().to_owned();
                     keys.push((key, k.clone()));
                 }
-                kvals.insert(k, value.json().as_bytes().to_owned());
-                return true;
+                kvals.insert(k, value.data.as_bytes().to_owned());
+                true
             });
-            return true;
+            true
         });
 
         for i in 0..keys.len() {
@@ -191,28 +190,27 @@ fn mod_flatten(json: &str, arg: &str) -> String {
         return json.to_owned();
     }
     let deep = get(arg, "deep").bool();
-    let mut out = Vec::new();
-    out.push(b'[');
+    let mut out = vec![b'['];
     let mut idx = 0;
     res.each(|_, value| {
         let raw;
         if value.kind() == Kind::Array {
             if deep {
-                raw = unwrap(mod_flatten(value.json(), arg).as_bytes()).to_owned();
+                raw = unwrap(mod_flatten(&value.data, arg).as_bytes()).to_owned();
             } else {
-                raw = unwrap(value.json().as_bytes()).to_owned();
+                raw = unwrap(value.data.as_bytes()).to_owned();
             }
         } else {
-            raw = value.slice.as_bytes().to_owned();
+            raw = value.data.as_bytes().to_owned();
         }
-        if raw.len() > 0 {
+        if !raw.is_empty() {
             if idx > 0 {
                 out.push(b',');
             }
             out.extend(&raw);
             idx += 1;
         }
-        return true;
+        true
     });
     out.push(b']');
     // SAFETY: buffer was constructed from known utf8 parts.
@@ -220,10 +218,10 @@ fn mod_flatten(json: &str, arg: &str) -> String {
 }
 
 fn unwrap<'a>(mut json: &'a [u8]) -> &'a [u8] {
-    while json.len() > 0 && json[0] <= b' ' {
+    while !json.is_empty() && json[0] <= b' ' {
         json = &json[1..];
     }
-    while json.len() > 0 && json[json.len() - 1] <= b' ' {
+    while !json.is_empty() && json[json.len() - 1] <= b' ' {
         json = &json[..json.len() - 1];
     }
     if json.len() >= 2 && (json[0] == b'[' || json[0] == b'{') {

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -13,46 +13,43 @@ use std::collections::HashMap;
 use std::str;
 
 pub fn exec<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
-    let (name, json_str, arg);
+    let (name, arg);
     // SAFETY: all json and path parts are prechecked utf8
     unsafe {
         if path.marg == 0 {
             name = str::from_utf8_unchecked(&path.comp[1..]);
-            json_str = str::from_utf8_unchecked(json);
             arg = "";
         } else {
             name = str::from_utf8_unchecked(&path.comp[1..path.marg]);
-            json_str = str::from_utf8_unchecked(json);
             arg = str::from_utf8_unchecked(&path.comp[path.marg + 1..]);
         }
     };
-    let json = json_str;
     let json = match name {
         "this" => mod_this(json, arg),
         "reverse" => mod_reverse(json, arg),
         "ugly" => mod_ugly(json, arg),
         "pretty" => mod_pretty(json, arg),
         "valid" => mod_valid(json, arg),
-        "flatten" => mod_flatten(json, arg),
+        "flatten" => mod_flatten(&json, arg),
         "join" => mod_join(json, arg),
-        _ => String::new(),
+        _ => Vec::new(),
     };
-    (json_into_owned(parse(&json)), path)
+    (json_into_owned(parse_bytes(&json)), path)
 }
 
-fn mod_this(json: &str, _: &str) -> String {
-    json.to_owned()
+fn mod_this(json: &[u8], _: &str) -> Vec<u8> {
+    json.to_vec()
 }
 
-fn mod_valid(json: &str, _: &str) -> String {
+fn mod_valid(json: &[u8], _: &str) -> Vec<u8> {
     if valid(json) {
-        json.to_owned()
+        json.to_vec()
     } else {
-        String::new()
+        Vec::new()
     }
 }
 
-fn mod_pretty(json: &str, arg: &str) -> String {
+fn mod_pretty(json: &[u8], arg: &str) -> Vec<u8> {
     if !arg.is_empty() {
         let mut opts = pretty::PrettyOptions::new();
         let indent = super::get(arg, "indent");
@@ -77,13 +74,13 @@ fn mod_pretty(json: &str, arg: &str) -> String {
     }
 }
 
-fn mod_ugly(json: &str, _: &str) -> String {
-    pretty::ugly(json)
+fn mod_ugly(json: &[u8], _: &str) -> Vec<u8> {
+    pretty::ugly_bytes(json)
 }
 
-fn mod_reverse(json: &str, _: &str) -> String {
-    let res = parse(json);
-    let json = res.data.as_bytes();
+fn mod_reverse(json: &[u8], _: &str) -> Vec<u8> {
+    let res = parse_bytes(json);
+    let json = &res.data;
     let mut slices = Vec::new();
     let endcaps;
     let mut cap = 2;
@@ -109,7 +106,7 @@ fn mod_reverse(json: &str, _: &str) -> String {
                 true
             });
         }
-        _ => return tostr(json).to_owned(),
+        _ => return json.to_vec(),
     }
     let mut out: Vec<u8> = Vec::with_capacity(cap);
     out.push(endcaps.0);
@@ -120,12 +117,11 @@ fn mod_reverse(json: &str, _: &str) -> String {
         out.extend(slices[slices.len() - 1 - i]);
     }
     out.push(endcaps.1);
-    // SAFETY: buffer was constructed from known utf8 parts.
-    unsafe { String::from_utf8_unchecked(out) }
+    out
 }
 
-fn mod_join(json: &str, arg: &str) -> String {
-    let res = parse(json);
+fn mod_join(json: &[u8], arg: &str) -> Vec<u8> {
+    let res = parse_bytes(json);
     if res.kind() != Kind::Array {
         return json.to_owned();
     }
@@ -141,7 +137,7 @@ fn mod_join(json: &str, arg: &str) -> String {
             if idx > 0 {
                 out.push(b',');
             }
-            out.extend(unwrap(value.data.as_bytes()));
+            out.extend(unwrap(&value.data));
             idx += 1;
             true
         });
@@ -156,10 +152,10 @@ fn mod_join(json: &str, arg: &str) -> String {
             value.each(|key, value| {
                 let k = key.str().as_bytes().to_owned();
                 if !kvals.contains_key(&k) {
-                    let key = key.data.as_bytes().to_owned();
+                    let key = key.data.into_owned();
                     keys.push((key, k.clone()));
                 }
-                kvals.insert(k, value.data.as_bytes().to_owned());
+                kvals.insert(k, value.data.into_owned());
                 true
             });
             true
@@ -175,8 +171,7 @@ fn mod_join(json: &str, arg: &str) -> String {
         }
     }
     out.push(b'}');
-    // SAFETY: buffer was constructed from known utf8 parts.
-    unsafe { String::from_utf8_unchecked(out) }
+    out
 }
 
 // @flatten an array with child arrays.
@@ -184,10 +179,10 @@ fn mod_join(json: &str, arg: &str) -> String {
 // The {"deep":true} arg can be provide for deep flattening.
 //   [1,[2],[3,4],[5,[6,7]]] -> [1,2,3,4,5,6,7]
 // The original json is returned when the json is not an array.
-fn mod_flatten(json: &str, arg: &str) -> String {
-    let res = parse(json);
+fn mod_flatten(json: &[u8], arg: &str) -> Vec<u8> {
+    let res = parse_bytes(json);
     if res.kind() != Kind::Array {
-        return json.to_owned();
+        return Vec::from(json);
     }
     let deep = get(arg, "deep").bool();
     let mut out = vec![b'['];
@@ -196,12 +191,12 @@ fn mod_flatten(json: &str, arg: &str) -> String {
         let raw;
         if value.kind() == Kind::Array {
             if deep {
-                raw = unwrap(mod_flatten(&value.data, arg).as_bytes()).to_owned();
+                raw = unwrap(&mod_flatten(&value.data, arg)).to_owned();
             } else {
-                raw = unwrap(value.data.as_bytes()).to_owned();
+                raw = unwrap(&value.data).to_owned();
             }
         } else {
-            raw = value.data.as_bytes().to_owned();
+            raw = Vec::from(value.data);
         }
         if !raw.is_empty() {
             if idx > 0 {
@@ -213,8 +208,7 @@ fn mod_flatten(json: &str, arg: &str) -> String {
         true
     });
     out.push(b']');
-    // SAFETY: buffer was constructed from known utf8 parts.
-    unsafe { String::from_utf8_unchecked(out) }
+    out
 }
 
 fn unwrap<'a>(mut json: &'a [u8]) -> &'a [u8] {

--- a/src/multipath.rs
+++ b/src/multipath.rs
@@ -115,13 +115,12 @@ fn exec_arr<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
             if index > 0 {
                 out.push(b',');
             }
-            out.extend(res.data.as_bytes());
+            out.extend(res.data.as_ref());
             index += 1;
         }
     });
     out.push(b']');
-    let json = unsafe { String::from_utf8_unchecked(out) };
-    (json_from_owned(json, None, INFO_ARRAY), path)
+    (json_from_owned(out, None, INFO_ARRAY), path)
 }
 
 fn exec_obj<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
@@ -138,11 +137,10 @@ fn exec_obj<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
             }
             extend_json_string(&mut out, key);
             out.push(b':');
-            out.extend(res.data.as_bytes());
+            out.extend(res.data.as_ref());
             index += 1;
         }
     });
     out.push(b'}');
-    let json = unsafe { String::from_utf8_unchecked(out) };
-    (json_from_owned(json, None, INFO_OBJECT), path)
+    (json_from_owned(out, None, INFO_OBJECT), path)
 }

--- a/src/multipath.rs
+++ b/src/multipath.rs
@@ -14,10 +14,8 @@ fn name_of_last<'a>(path: &'a [u8]) -> &'a [u8] {
     for i in 0..path.len() {
         let i = path.len() - 1 - i;
         if path[i] == b'|' || path[i] == b'.' {
-            if i > 0 {
-                if path[i - 1] == b'\\' {
-                    continue;
-                }
+            if i > 0 && path[i - 1] == b'\\' {
+                continue;
             }
             return &path[i + 1..];
         }
@@ -28,11 +26,12 @@ fn name_of_last<'a>(path: &'a [u8]) -> &'a [u8] {
 // is_simple_name returns true if the component name is simple enough to use as
 // a multipath key.
 fn is_simple_name(comp: &[u8]) -> bool {
-    for i in 0..comp.len() {
-        if comp[i] < b' ' {
+    for i in comp {
+        let i = *i;
+        if i < b' ' {
             return false;
         }
-        match comp[i] {
+        match i {
             b'[' | b']' | b'{' | b'}' | b'(' | b')' | b'#' | b'|' => {
                 return false;
             }
@@ -108,8 +107,7 @@ fn exec_arr<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
     if path.comp[0] == b'[' && path.comp[path.comp.len() - 1] != b']' {
         return (Value::default(), Path::default());
     }
-    let mut out = Vec::new();
-    out.push(b'[');
+    let mut out = vec![b'['];
     let mut index = 0;
     each_comp(path.comp, |_, path| {
         let res = get(tostr(json), tostr(path));
@@ -117,7 +115,7 @@ fn exec_arr<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
             if index > 0 {
                 out.push(b',');
             }
-            out.extend(res.json().as_bytes());
+            out.extend(res.data.as_bytes());
             index += 1;
         }
     });
@@ -130,8 +128,7 @@ fn exec_obj<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
     if path.comp[0] == b'{' && path.comp[path.comp.len() - 1] != b'}' {
         return (Value::default(), Path::default());
     }
-    let mut out = Vec::new();
-    out.push(b'{');
+    let mut out = vec![b'{'];
     let mut index = 0;
     each_comp(path.comp, |key, path| {
         let res = get(tostr(json), tostr(path));
@@ -141,7 +138,7 @@ fn exec_obj<'a>(json: &'a [u8], path: Path<'a>) -> (Value<'a>, Path<'a>) {
             }
             extend_json_string(&mut out, key);
             out.push(b':');
-            out.extend(res.json().as_bytes());
+            out.extend(res.data.as_bytes());
             index += 1;
         }
     });

--- a/src/path.rs
+++ b/src/path.rs
@@ -261,7 +261,7 @@ fn path_next_multipath<'a>(path: &Path<'a>) -> Path<'a> {
         comp: &path.extra[..e],
         esc: false,
         pat: false,
-        sep: sep,
+        sep,
         marg: 0,
         extra: &path.extra[s..],
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -20,7 +20,7 @@ pub struct Path<'a> {
 
 impl<'a> Path<'a> {
     pub fn more(&self) -> bool {
-        return self.sep != 0;
+        self.sep != 0
     }
     pub fn new(path: &'a str) -> Self {
         let path = Path {
@@ -34,10 +34,10 @@ impl<'a> Path<'a> {
         path_next(&path)
     }
     pub fn is_modifier(&self) -> bool {
-        self.comp.len() > 0 && self.comp[0] == b'@'
+        !self.comp.is_empty() && self.comp[0] == b'@'
     }
     pub fn is_multipath(&self) -> bool {
-        self.comp.len() > 0 && (self.comp[0] == b'{' || self.comp[0] == b'[')
+        !self.comp.is_empty() && (self.comp[0] == b'{' || self.comp[0] == b'[')
     }
     // next returns the next component
     pub fn next(&self) -> Path<'a> {
@@ -69,7 +69,7 @@ impl<'a> Path<'a> {
         }
         let group = tostr(&self.extra[..len]);
         remaining.comp = "".as_bytes();
-        return (group, remaining);
+        (group, remaining)
     }
 
     // -> lh, op, rh
@@ -83,10 +83,10 @@ impl<'a> Path<'a> {
             if query.len() < 2 || query[0] != b'#' || query[1] != b'(' {
                 break 'bad;
             } else if query[query.len() - 1] == b'#' {
-                if query[query.len() - 2] != b')' {
-                    break 'bad;
-                } else {
+                if query[query.len() - 2] == b')' {
                     query = &query[2..query.len() - 2];
+                } else {
+                    break 'bad;
                 }
             } else if query[query.len() - 1] != b')' {
                 break 'bad;
@@ -229,9 +229,9 @@ fn path_next_query<'a>(path: &Path<'a>) -> Path<'a> {
         comp: &path.extra[..i],
         esc: false,
         pat: false,
-        sep: sep,
+        sep,
         marg: 0,
-        extra: extra,
+        extra,
     };
     if path.comp[path.comp.len() - 1] == b'#' {
         if path.comp[path.comp.len() - 2] != b')' {
@@ -275,7 +275,7 @@ fn path_next<'a>(path: &Path<'a>) -> Path<'a> {
     let mut pat = false;
     let mut modi = false;
     let mut marg = 0;
-    if path.extra.len() > 0 {
+    if !path.extra.is_empty() {
         if path.extra[0] == b'@' {
             modi = true;
         } else if path.extra[0] == b'#' {
@@ -321,7 +321,7 @@ fn path_next<'a>(path: &Path<'a>) -> Path<'a> {
             }
             break;
         } else if path.extra[i] == b'*' || path.extra[i] == b'?' {
-            pat = true
+            pat = true;
         } else if path.extra[i] == b'.' || path.extra[i] == b'|' {
             sep = path.extra[i];
             i += 1;
@@ -335,10 +335,10 @@ fn path_next<'a>(path: &Path<'a>) -> Path<'a> {
         } else {
             &path.extra[..i - 1]
         },
-        esc: esc,
-        pat: pat,
-        sep: sep,
-        marg: marg,
+        esc,
+        pat,
+        sep,
+        marg,
         extra: &path.extra[i..],
     }
 }

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -6,7 +6,6 @@
 // provides additional information about the data
 
 use std::cmp::Ordering;
-use std::mem;
 
 // maxDepth is maximum number of nested objects and arrays
 const MAX_DEPTH: usize = 500;
@@ -63,26 +62,16 @@ impl<'a> PrettyOptions<'a> {
         self.inner.sort_keys = sort_keys;
         self
     }
-    pub fn pretty<J>(&self, json: J) -> String
-    where
-        J: AsRef<str>,
-    {
+    pub fn pretty(&self, json: &[u8]) -> Vec<u8> {
         pretty_options(json, self)
     }
 }
 
-pub fn pretty<J>(json: J) -> String
-where
-    J: AsRef<str>,
-{
+pub fn pretty(json: &[u8]) -> Vec<u8> {
     PrettyOptions::default().pretty(json)
 }
 
-fn pretty_options<J>(json: J, opts: &PrettyOptions) -> String
-where
-    J: AsRef<str>,
-{
-    let json = json.as_ref().as_bytes();
+fn pretty_options(json: &[u8], opts: &PrettyOptions) -> Vec<u8> {
     let mut buf = Vec::with_capacity(json.len());
     let prefix = opts.inner.prefix.as_bytes();
     if !prefix.is_empty() {
@@ -105,7 +94,7 @@ where
     if !buf.is_empty() {
         buf.push(b'\n');
     }
-    unsafe { mem::transmute::<Vec<u8>, String>(buf) }
+    buf
 }
 
 fn extend_pretty_any(
@@ -270,8 +259,8 @@ fn extend_pretty_object(
     depth: usize,
 ) -> (usize, i64, bool) {
     if depth == MAX_DEPTH {
-        let fragment = ugly(unsafe { std::str::from_utf8_unchecked(&json[i..]) });
-        buf.extend(fragment.as_bytes());
+        let fragment = ugly_bytes(&json[i..]);
+        buf.extend(fragment);
         return (json.len(), nl, true);
     }
     let mut ok;
@@ -441,9 +430,8 @@ fn extend_tabs(buf: &mut Vec<u8>, prefix: &[u8], indent: &[u8], tabs: i64) {
     }
 }
 
-pub fn ugly(json: &str) -> String {
-    let src = json.as_bytes();
-    let mut dst = Vec::with_capacity(json.len());
+pub fn ugly_bytes(src: &[u8]) -> Vec<u8> {
+    let mut dst = Vec::with_capacity(src.len());
     let mut i = 0;
     while i < src.len() {
         if src[i] > b' ' {
@@ -470,7 +458,11 @@ pub fn ugly(json: &str) -> String {
         }
         i += 1;
     }
-    unsafe { mem::transmute::<Vec<u8>, String>(dst) }
+    dst
+}
+
+pub fn ugly(json: &str) -> Vec<u8> {
+    ugly_bytes(json.as_bytes())
 }
 
 #[cfg(test)]
@@ -507,18 +499,24 @@ mod test {
 
     #[test]
     fn ugly() {
-        assert_eq!(super::ugly(EXAMPLE_PRETTY), EXAMPLE_UGLY);
-        assert_eq!(super::pretty(super::ugly(EXAMPLE_PRETTY)), EXAMPLE_PRETTY);
+        assert_eq!(super::ugly(EXAMPLE_PRETTY), EXAMPLE_UGLY.as_bytes());
+        assert_eq!(
+            super::pretty(&super::ugly(EXAMPLE_PRETTY)),
+            EXAMPLE_PRETTY.as_bytes()
+        );
     }
     #[test]
     fn pretty() {
-        assert_eq!(super::pretty(EXAMPLE_UGLY), EXAMPLE_PRETTY);
+        assert_eq!(
+            super::pretty(EXAMPLE_UGLY.as_bytes()),
+            EXAMPLE_PRETTY.as_bytes()
+        );
         let res = super::PrettyOptions::new()
             .prefix("\t")
             .width(10)
             .sort_keys(true)
             .indent("   ")
-            .pretty(EXAMPLE_UGLY);
+            .pretty(EXAMPLE_UGLY.as_bytes());
         let expect = r#"	{
 	   "children": [
 	      "Andy",
@@ -556,23 +554,23 @@ mod test {
 	   "values3": []
 	}
 "#;
-        assert_eq!(res, expect);
+        assert_eq!(res, expect.as_bytes());
     }
 
     #[test]
     fn xcover() {
-        let res = super::ugly(
+        let res = super::ugly_bytes(
             &super::PrettyOptions::new()
                 .sort_keys(true)
-                .pretty(r#"{"hello":"JELLO","hello":"HELLO"}"#),
+                .pretty(r#"{"hello":"JELLO","hello":"HELLO"}"#.as_bytes()),
         );
-        assert_eq!(res, r#"{"hello":"JELLO","hello":"HELLO"}"#);
+        assert_eq!(res, r#"{"hello":"JELLO","hello":"HELLO"}"#.as_bytes());
         super::PrettyOptions::new()
             .sort_keys(true)
-            .pretty(r#"{"hello":"JELLO","hello":"HELLO"}"#);
+            .pretty(r#"{"hello":"JELLO","hello":"HELLO"}"#.as_bytes());
 
-        super::pretty(r#"{"#);
-        super::pretty(r#"r"#);
+        super::pretty(r#"{"#.as_bytes());
+        super::pretty(r#"r"#.as_bytes());
     }
 
     #[test]
@@ -653,6 +651,9 @@ mod test {
       ]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]      
       "#;
 
-        println!("{}", super::pretty(JSON));
+        println!(
+            "{}",
+            String::from_utf8_lossy(&super::pretty(JSON.as_bytes()))
+        );
     }
 }

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -85,7 +85,7 @@ where
     let json = json.as_ref().as_bytes();
     let mut buf = Vec::with_capacity(json.len());
     let prefix = opts.inner.prefix.as_bytes();
-    if prefix.len() != 0 {
+    if !prefix.is_empty() {
         buf.extend(prefix);
     }
     extend_pretty_any(
@@ -102,7 +102,7 @@ where
         -1,
         0,
     );
-    if buf.len() > 0 {
+    if !buf.is_empty() {
         buf.push(b'\n');
     }
     unsafe { mem::transmute::<Vec<u8>, String>(buf) }
@@ -404,7 +404,7 @@ fn extend_pretty_object(
 }
 
 fn sort_pairs(json: &[u8], buf: &mut Vec<u8>, pairs: &mut Vec<Pair>) {
-    if pairs.len() == 0 {
+    if pairs.is_empty() {
         return;
     }
     let vstart = pairs[0].vstart;
@@ -433,7 +433,7 @@ fn sort_pairs(json: &[u8], buf: &mut Vec<u8>, pairs: &mut Vec<Pair>) {
 }
 
 fn extend_tabs(buf: &mut Vec<u8>, prefix: &[u8], indent: &[u8], tabs: i64) {
-    if prefix.len() != 0 {
+    if !prefix.is_empty() {
         buf.extend(prefix);
     }
     for _ in 0..tabs {

--- a/src/test.rs
+++ b/src/test.rs
@@ -68,7 +68,10 @@ fn modifiers() {
     ]}"#,
         "user.@join.@ugly",
     );
-    assert_eq!(res.data, r#"{"first":"tom","age":68,"last":"anderson"}"#);
+    assert_eq!(
+        res.data,
+        r#"{"first":"tom","age":68,"last":"anderson"}"#.as_bytes()
+    );
     let res = get(
         r#"{"user":[
         {"first":"tom","age":72},
@@ -78,16 +81,16 @@ fn modifiers() {
     );
     assert_eq!(
         res.data,
-        r#"{"first":"tom","age":72,"last":"anderson","age":68}"#
+        r#"{"first":"tom","age":72,"last":"anderson","age":68}"#.as_bytes()
     );
 
     assert_eq!(
         get("[1,[2],[3,4],[5,[6,7]]]", "@flatten").data,
-        "[1,2,3,4,5,[6,7]]"
+        "[1,2,3,4,5,[6,7]]".as_bytes()
     );
     assert_eq!(
         get("[1,[2],[3,4],[5,[6,7]]]", r#"@flatten:{"deep":true}"#).data,
-        "[1,2,3,4,5,6,7]"
+        "[1,2,3,4,5,6,7]".as_bytes()
     );
 }
 
@@ -103,7 +106,7 @@ fn iterator() {
                 if index > 0 {
                     res.push_str(",");
                 }
-                res.push_str(&value.get("user.name").data);
+                res.push_str(&String::from_utf8_lossy(&value.get("user.name").data));
                 index += 1;
                 return true;
             });
@@ -140,7 +143,7 @@ fn query() {
         "statuses.#(user.profile_link_color!=0084B4)#.id|@ugly",
     );
     assert_eq!(
-        res.str(),
+        res.str().as_bytes(),
         pretty::ugly(
             "[505874919020699648,505874915338104833,505874914897690624,
         505874893154426881,505874882870009856,505874882228281345,
@@ -162,7 +165,7 @@ fn query() {
         "#;
     assert_eq!(
         get(json, r#"frie\nds.#(ne\ts.#(ne\t=ig)).@ugly"#).data,
-        r#"{"first":"Dale","last":"Murphy","age":44,"nets":[{"net":"ig"},"fb","tw"]}"#
+        r#"{"first":"Dale","last":"Murphy","age":44,"nets":[{"net":"ig"},"fb","tw"]}"#.as_bytes()
     );
 }
 
@@ -175,7 +178,7 @@ fn multipath() {
     );
     assert_eq!(
         res.data,
-        r#"[[100,100],"モテモテ大作戦★男子編",[2278053589,2714868440,2714526565]]"#
+        r#"[[100,100],"モテモテ大作戦★男子編",[2278053589,2714868440,2714526565]]"#.as_bytes()
     );
     let res = get(
         &json,
@@ -183,7 +186,7 @@ fn multipath() {
     );
     assert_eq!(
         res.data,
-        r#"{"_":[100,100],"name":"モテモテ大作戦★男子編","@reverse":[2278053589,2714868440,2714526565]}"#
+        r#"{"_":[100,100],"name":"モテモテ大作戦★男子編","@reverse":[2278053589,2714868440,2714526565]}"#.as_bytes()
     );
     let res = get(
         &json,
@@ -191,7 +194,7 @@ fn multipath() {
     );
     assert_eq!(
         res.data,
-        r#"{"counts":[100,100],"name":"モテモテ大作戦★男子編","@reverse":[2278053589,2714868440,2714526565]}"#
+        r#"{"counts":[100,100],"name":"モテモテ大作戦★男子編","@reverse":[2278053589,2714868440,2714526565]}"#.as_bytes()
     );
 }
 
@@ -209,9 +212,12 @@ fn jsonlines() {
     assert_eq!(get(json, "..1.a").i32(), 2);
     assert_eq!(
         get(json, "..#.@this|@ugly").data,
-        r#"[{"a":1},{"a":2},true,false,4]"#
+        r#"[{"a":1},{"a":2},true,false,4]"#.as_bytes()
     );
-    assert_eq!(get(json, "..#.@this|@join|@ugly").data, r#"{"a":2}"#);
+    assert_eq!(
+        get(json, "..#.@this|@join|@ugly").data,
+        r#"{"a":2}"#.as_bytes()
+    );
 }
 
 #[test]
@@ -249,8 +255,8 @@ const EXAMPLE: &str = r#"
 #[cfg(test)]
 fn exec_simple_fuzz(data: &[u8]) {
     if let Ok(s) = std::str::from_utf8(data) {
-        let _ = std::str::from_utf8(get(s, s).data.as_bytes()).unwrap();
-        let _ = std::str::from_utf8(get(EXAMPLE, s).data.as_bytes()).unwrap();
+        let _ = std::str::from_utf8(&get(s, s).data).unwrap();
+        let _ = std::str::from_utf8(&get(EXAMPLE, s).data).unwrap();
     }
 }
 
@@ -341,6 +347,9 @@ fn bool_convert_query() {
 	}
     "#;
 
-    assert_eq!(get(JSON, r#"vals.#(b==~true)#.a"#).data, "[1,2,6,7,8]");
+    assert_eq!(
+        get(JSON, r#"vals.#(b==~true)#.a"#).data,
+        "[1,2,6,7,8]".as_bytes()
+    );
     // assert_eq!(get(JSON, r#"vals.#(b==~false)#.a"#).json(), "[3,4,5,9,10,11]");
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -68,7 +68,7 @@ fn modifiers() {
     ]}"#,
         "user.@join.@ugly",
     );
-    assert_eq!(res.json(), r#"{"first":"tom","age":68,"last":"anderson"}"#);
+    assert_eq!(res.data, r#"{"first":"tom","age":68,"last":"anderson"}"#);
     let res = get(
         r#"{"user":[
         {"first":"tom","age":72},
@@ -77,16 +77,16 @@ fn modifiers() {
         r#"user.@join:{"preserve":true}.@ugly"#,
     );
     assert_eq!(
-        res.json(),
+        res.data,
         r#"{"first":"tom","age":72,"last":"anderson","age":68}"#
     );
 
     assert_eq!(
-        get("[1,[2],[3,4],[5,[6,7]]]", "@flatten").json(),
+        get("[1,[2],[3,4],[5,[6,7]]]", "@flatten").data,
         "[1,2,3,4,5,[6,7]]"
     );
     assert_eq!(
-        get("[1,[2],[3,4],[5,[6,7]]]", r#"@flatten:{"deep":true}"#).json(),
+        get("[1,[2],[3,4],[5,[6,7]]]", r#"@flatten:{"deep":true}"#).data,
         "[1,2,3,4,5,6,7]"
     );
 }
@@ -103,12 +103,12 @@ fn iterator() {
                 if index > 0 {
                     res.push_str(",");
                 }
-                res.push_str(value.get("user.name").json());
+                res.push_str(&value.get("user.name").data);
                 index += 1;
                 return true;
-            })
+            });
         }
-        return true;
+        true
     });
     res.push_str("]");
     assert_eq!(index, 100);
@@ -161,7 +161,7 @@ fn query() {
         }
         "#;
     assert_eq!(
-        get(json, r#"frie\nds.#(ne\ts.#(ne\t=ig)).@ugly"#).json(),
+        get(json, r#"frie\nds.#(ne\ts.#(ne\t=ig)).@ugly"#).data,
         r#"{"first":"Dale","last":"Murphy","age":44,"nets":[{"net":"ig"},"fb","tw"]}"#
     );
 }
@@ -174,7 +174,7 @@ fn multipath() {
         r#"[[statuses.#,statuses.#],statuses.10.user.name,[statuses.10.user.id,statuses.56.user.id,statuses.42.user.id].@reverse]"#,
     );
     assert_eq!(
-        res.json(),
+        res.data,
         r#"[[100,100],"モテモテ大作戦★男子編",[2278053589,2714868440,2714526565]]"#
     );
     let res = get(
@@ -182,7 +182,7 @@ fn multipath() {
         r#"{[statuses.#,statuses.#],statuses.10.user.name,[statuses.10.user.id,statuses.56.user.id,statuses.42.user.id].@reverse}"#,
     );
     assert_eq!(
-        res.json(),
+        res.data,
         r#"{"_":[100,100],"name":"モテモテ大作戦★男子編","@reverse":[2278053589,2714868440,2714526565]}"#
     );
     let res = get(
@@ -190,7 +190,7 @@ fn multipath() {
         r#"{counts:[statuses.#,statuses.#],statuses.10.user.name,[statuses.10.user.id,statuses.56.user.id,statuses.42.user.id].@reverse}"#,
     );
     assert_eq!(
-        res.json(),
+        res.data,
         r#"{"counts":[100,100],"name":"モテモテ大作戦★男子編","@reverse":[2278053589,2714868440,2714526565]}"#
     );
 }
@@ -208,10 +208,10 @@ fn jsonlines() {
     assert_eq!(get(json, "..0.a").i32(), 1);
     assert_eq!(get(json, "..1.a").i32(), 2);
     assert_eq!(
-        get(json, "..#.@this|@ugly").json(),
+        get(json, "..#.@this|@ugly").data,
         r#"[{"a":1},{"a":2},true,false,4]"#
     );
-    assert_eq!(get(json, "..#.@this|@join|@ugly").json(), r#"{"a":2}"#);
+    assert_eq!(get(json, "..#.@this|@join|@ugly").data, r#"{"a":2}"#);
 }
 
 #[test]
@@ -249,8 +249,8 @@ const EXAMPLE: &str = r#"
 #[cfg(test)]
 fn exec_simple_fuzz(data: &[u8]) {
     if let Ok(s) = std::str::from_utf8(data) {
-        let _ = std::str::from_utf8(get(s, s).json().as_bytes()).unwrap();
-        let _ = std::str::from_utf8(get(EXAMPLE, s).json().as_bytes()).unwrap();
+        let _ = std::str::from_utf8(get(s, s).data.as_bytes()).unwrap();
+        let _ = std::str::from_utf8(get(EXAMPLE, s).data.as_bytes()).unwrap();
     }
 }
 
@@ -321,7 +321,6 @@ fn escaped_query_string() {
     assert_eq!(get(JSON, r#"friends.#(last="Murphy").age"#).i32(), 47);
 }
 
-
 #[test]
 fn bool_convert_query() {
     const JSON: &str = r#"
@@ -342,6 +341,6 @@ fn bool_convert_query() {
 	}
     "#;
 
-    assert_eq!(get(JSON, r#"vals.#(b==~true)#.a"#).json(), "[1,2,6,7,8]");
+    assert_eq!(get(JSON, r#"vals.#(b==~true)#.a"#).data, "[1,2,6,7,8]");
     // assert_eq!(get(JSON, r#"vals.#(b==~false)#.a"#).json(), "[3,4,5,9,10,11]");
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -28,12 +28,12 @@ fn modifiers() {
     let res2 = get(&json, "statuses.#.user.id|@reverse|@valid");
     let mut all1 = Vec::new();
     res1.each(|_, value| {
-        all1.push(value.str().to_owned());
+        all1.push(value.str().into_owned());
         true
     });
     let mut all2 = Vec::new();
     res2.each(|_, value| {
-        all2.push(value.str().to_owned());
+        all2.push(value.str().into_owned());
         true
     });
     assert_eq!(all1.len(), 100);
@@ -46,12 +46,12 @@ fn modifiers() {
     let res2 = get(&json, "statuses.50.user|@reverse|@valid");
     let mut all1 = Vec::new();
     res1.each(|key, value| {
-        all1.push((key.str().to_owned(), value.str().to_owned()));
+        all1.push((key.str().into_owned(), value.str().into_owned()));
         true
     });
     let mut all2 = Vec::new();
     res2.each(|key, value| {
-        all2.push((key.str().to_owned(), value.str().to_owned()));
+        all2.push((key.str().into_owned(), value.str().into_owned()));
         true
     });
     assert_eq!(all1.len(), 40);

--- a/src/util.rs
+++ b/src/util.rs
@@ -255,8 +255,8 @@ LINE交換できる？:あぁ……ごめん✋
 
         let raw1 = r#""\n第一印象:なんか怖っ！\n今の印象:とりあえずキモい。噛み合わない\n好きなところ:ぶすでキモいとこ😋✨✨\n思い出:んーーー、ありすぎ😊❤️\nLINE交換できる？:あぁ……ごめん✋\nトプ画をみて:照れますがな😘✨\n一言:お前は一生もんのダチ💖""#;
         let raw2 = r#""\n\u7B2C\u4E00\u5370\u8C61:\u306A\u3093\u304B\u6016\u3063\uFF01\n\u4ECA\u306E\u5370\u8C61:\u3068\u308A\u3042\u3048\u305A\u30AD\u30E2\u3044\u3002\u565B\u307F\u5408\u308F\u306A\u3044\n\u597D\u304D\u306A\u3068\u3053\u308D:\u3076\u3059\u3067\u30AD\u30E2\u3044\u3068\u3053\uD83D\uDE0B\u2728\u2728\n\u601D\u3044\u51FA:\u3093\u30FC\u30FC\u30FC\u3001\u3042\u308A\u3059\u304E\uD83D\uDE0A\u2764\uFE0F\nLINE\u4EA4\u63DB\u3067\u304D\u308B\uFF1F:\u3042\u3041\u2026\u2026\u3054\u3081\u3093\u270B\n\u30C8\u30D7\u753B\u3092\u307F\u3066:\u7167\u308C\u307E\u3059\u304C\u306A\uD83D\uDE18\u2728\n\u4E00\u8A00:\u304A\u524D\u306F\u4E00\u751F\u3082\u3093\u306E\u30C0\u30C1\uD83D\uDC96""#;
-        assert_eq!(text, super::unescape(raw1));
-        assert_eq!(text, super::unescape(raw2));
+        assert_eq!(text, super::unescape(raw1.as_bytes()));
+        assert_eq!(text, super::unescape(raw2.as_bytes()));
         assert_eq!(super::escape(text), raw1);
 
         assert_eq!(
@@ -267,15 +267,15 @@ LINE交換できる？:あぁ……ごめん✋
 
     #[test]
     fn unescape() {
-        assert_eq!(super::unescape(r#""adsf"#), "");
-        assert_eq!(super::unescape(r#""ad\sf""#), "ad");
+        assert_eq!(super::unescape(r#""adsf"#.as_bytes()), "");
+        assert_eq!(super::unescape(r#""ad\sf""#.as_bytes()), "ad");
         assert_eq!(
-            super::unescape(r#""ad\"\\\/\b\f\n\r\tsf""#),
+            super::unescape(r#""ad\"\\\/\b\f\n\r\tsf""#.as_bytes()),
             "ad\"\\/\u{08}\u{0C}\n\r\tsf"
         );
-        assert_eq!(super::unescape(r#""ad\uD83Dsf""#), "ad�sf");
-        assert_eq!(super::unescape(r#""ad\uD83D\usf""#), "ad�");
-        assert_eq!(super::unescape(r#""ad\uD83D\uxxxxsf""#), "ad�sf");
-        assert_eq!(super::unescape(r#""ad\uD83D\u00FFsf""#), "ad�sf");
+        assert_eq!(super::unescape(r#""ad\uD83Dsf""#.as_bytes()), "ad�sf");
+        assert_eq!(super::unescape(r#""ad\uD83D\usf""#.as_bytes()), "ad�");
+        assert_eq!(super::unescape(r#""ad\uD83D\uxxxxsf""#.as_bytes()), "ad�sf");
+        assert_eq!(super::unescape(r#""ad\uD83D\u00FFsf""#.as_bytes()), "ad�sf");
     }
 }

--- a/src/valid.rs
+++ b/src/valid.rs
@@ -65,8 +65,7 @@ fn isspace(c: u8) -> bool {
 /// }
 /// let value = gjson::get(json, "name.last");
 /// ```
-pub fn valid(json: &str) -> bool {
-    let json = json.as_bytes();
+pub fn valid(json: &[u8]) -> bool {
     let mut i = 0;
     let (valid, next_i) = valid_any(json, i);
     if !valid {
@@ -365,100 +364,106 @@ mod test {
 
     #[test]
     fn basic() {
-        assert_eq!(valid("0"), true);
-        assert_eq!(valid("00"), false);
-        assert_eq!(valid("-00"), false);
-        assert_eq!(valid("-."), false);
-        assert_eq!(valid("-.123"), false);
-        assert_eq!(valid("0.0"), true);
-        assert_eq!(valid("10.0"), true);
-        assert_eq!(valid("10e1"), true);
-        assert_eq!(valid("10EE"), false);
-        assert_eq!(valid("10E-"), false);
-        assert_eq!(valid("10E+"), false);
-        assert_eq!(valid("10E123"), true);
-        assert_eq!(valid("10E-123"), true);
-        assert_eq!(valid("10E-0123"), true);
-        assert_eq!(valid(""), false);
-        assert_eq!(valid(" "), false);
-        assert_eq!(valid("{}"), true);
-        assert_eq!(valid("{"), false);
-        assert_eq!(valid("-"), false);
-        assert_eq!(valid("-1"), true);
-        assert_eq!(valid("-1."), false);
-        assert_eq!(valid("-1.0"), true);
-        assert_eq!(valid(" -1.0"), true);
-        assert_eq!(valid(" -1.0 "), true);
-        assert_eq!(valid("-1.0 "), true);
-        assert_eq!(valid("-1.0 i"), false);
-        assert_eq!(valid("-1.0 i"), false);
-        assert_eq!(valid("true"), true);
-        assert_eq!(valid(" true"), true);
-        assert_eq!(valid(" true "), true);
-        assert_eq!(valid(" True "), false);
-        assert_eq!(valid(" tru"), false);
-        assert_eq!(valid("false"), true);
-        assert_eq!(valid(" false"), true);
-        assert_eq!(valid(" false "), true);
-        assert_eq!(valid(" False "), false);
-        assert_eq!(valid(" fals"), false);
-        assert_eq!(valid("null"), true);
-        assert_eq!(valid(" null"), true);
-        assert_eq!(valid(" null "), true);
-        assert_eq!(valid(" Null "), false);
-        assert_eq!(valid(" nul"), false);
-        assert_eq!(valid(" []"), true);
-        assert_eq!(valid(" [true]"), true);
-        assert_eq!(valid(" [ true, null ]"), true);
-        assert_eq!(valid(" [ true,]"), false);
-        assert_eq!(valid(r#"{"hello":"world"}"#), true);
-        assert_eq!(valid(r#"{ "hello": "world" }"#), true);
-        assert_eq!(valid(r#"{ "hello": "world", }"#), false);
-        assert_eq!(valid(r#"{"a":"b",}"#), false);
-        assert_eq!(valid(r#"{"a":"b","a"}"#), false);
-        assert_eq!(valid(r#"{"a":"b","a":}"#), false);
-        assert_eq!(valid(r#"{"a":"b","a":1}"#), true);
-        assert_eq!(valid(r#"{"a":"b",2"1":2}"#), false);
-        assert_eq!(valid(r#"{"a":"b","a": 1, "c":{"hi":"there"} }"#), true);
+        assert_eq!(valid("0".as_bytes()), true);
+        assert_eq!(valid("00".as_bytes()), false);
+        assert_eq!(valid("-00".as_bytes()), false);
+        assert_eq!(valid("-.".as_bytes()), false);
+        assert_eq!(valid("-.123".as_bytes()), false);
+        assert_eq!(valid("0.0".as_bytes()), true);
+        assert_eq!(valid("10.0".as_bytes()), true);
+        assert_eq!(valid("10e1".as_bytes()), true);
+        assert_eq!(valid("10EE".as_bytes()), false);
+        assert_eq!(valid("10E-".as_bytes()), false);
+        assert_eq!(valid("10E+".as_bytes()), false);
+        assert_eq!(valid("10E123".as_bytes()), true);
+        assert_eq!(valid("10E-123".as_bytes()), true);
+        assert_eq!(valid("10E-0123".as_bytes()), true);
+        assert_eq!(valid("".as_bytes()), false);
+        assert_eq!(valid(" ".as_bytes()), false);
+        assert_eq!(valid("{}".as_bytes()), true);
+        assert_eq!(valid("{".as_bytes()), false);
+        assert_eq!(valid("-".as_bytes()), false);
+        assert_eq!(valid("-1".as_bytes()), true);
+        assert_eq!(valid("-1.".as_bytes()), false);
+        assert_eq!(valid("-1.0".as_bytes()), true);
+        assert_eq!(valid(" -1.0".as_bytes()), true);
+        assert_eq!(valid(" -1.0 ".as_bytes()), true);
+        assert_eq!(valid("-1.0 ".as_bytes()), true);
+        assert_eq!(valid("-1.0 i".as_bytes()), false);
+        assert_eq!(valid("-1.0 i".as_bytes()), false);
+        assert_eq!(valid("true".as_bytes()), true);
+        assert_eq!(valid(" true".as_bytes()), true);
+        assert_eq!(valid(" true ".as_bytes()), true);
+        assert_eq!(valid(" True ".as_bytes()), false);
+        assert_eq!(valid(" tru".as_bytes()), false);
+        assert_eq!(valid("false".as_bytes()), true);
+        assert_eq!(valid(" false".as_bytes()), true);
+        assert_eq!(valid(" false ".as_bytes()), true);
+        assert_eq!(valid(" False ".as_bytes()), false);
+        assert_eq!(valid(" fals".as_bytes()), false);
+        assert_eq!(valid("null".as_bytes()), true);
+        assert_eq!(valid(" null".as_bytes()), true);
+        assert_eq!(valid(" null ".as_bytes()), true);
+        assert_eq!(valid(" Null ".as_bytes()), false);
+        assert_eq!(valid(" nul".as_bytes()), false);
+        assert_eq!(valid(" []".as_bytes()), true);
+        assert_eq!(valid(" [true]".as_bytes()), true);
+        assert_eq!(valid(" [ true, null ]".as_bytes()), true);
+        assert_eq!(valid(" [ true,]".as_bytes()), false);
+        assert_eq!(valid(r#"{"hello":"world"}"#.as_bytes()), true);
+        assert_eq!(valid(r#"{ "hello": "world" }"#.as_bytes()), true);
+        assert_eq!(valid(r#"{ "hello": "world", }"#.as_bytes()), false);
+        assert_eq!(valid(r#"{"a":"b",}"#.as_bytes()), false);
+        assert_eq!(valid(r#"{"a":"b","a"}"#.as_bytes()), false);
+        assert_eq!(valid(r#"{"a":"b","a":}"#.as_bytes()), false);
+        assert_eq!(valid(r#"{"a":"b","a":1}"#.as_bytes()), true);
+        assert_eq!(valid(r#"{"a":"b",2"1":2}"#.as_bytes()), false);
         assert_eq!(
-            valid(r#"{"a":"b","a": 1, "c":{"hi":"there", "easy":["going",{"mixed":"bag"}]} }"#),
+            valid(r#"{"a":"b","a": 1, "c":{"hi":"there"} }"#.as_bytes()),
             true
         );
-        assert_eq!(valid(r#""""#), true);
-        assert_eq!(valid(r#"""#), false);
-        assert_eq!(valid(r#""\n""#), true);
-        assert_eq!(valid(r#""\""#), false);
-        assert_eq!(valid(r#""\\""#), true);
-        assert_eq!(valid(r#""a\\b""#), true);
-        assert_eq!(valid(r#""a\\b\\\"a""#), true);
-        assert_eq!(valid(r#""a\\b\\\uFFAAa""#), true);
-        assert_eq!(valid(r#""a\\b\\\uFFAZa""#), false);
-        assert_eq!(valid(r#""a\\b\\\uFFA""#), false);
-        assert_eq!(valid(r#""a\\b\\\uFFAZa""#), false);
-        assert_eq!(valid(r#""#), false);
-        assert_eq!(valid("[-]"), false);
-        assert_eq!(valid("[-.123]"), false);
+        assert_eq!(
+            valid(
+                r#"{"a":"b","a": 1, "c":{"hi":"there", "easy":["going",{"mixed":"bag"}]} }"#
+                    .as_bytes()
+            ),
+            true
+        );
+        assert_eq!(valid(r#""""#.as_bytes()), true);
+        assert_eq!(valid(r#"""#.as_bytes()), false);
+        assert_eq!(valid(r#""\n""#.as_bytes()), true);
+        assert_eq!(valid(r#""\""#.as_bytes()), false);
+        assert_eq!(valid(r#""\\""#.as_bytes()), true);
+        assert_eq!(valid(r#""a\\b""#.as_bytes()), true);
+        assert_eq!(valid(r#""a\\b\\\"a""#.as_bytes()), true);
+        assert_eq!(valid(r#""a\\b\\\uFFAAa""#.as_bytes()), true);
+        assert_eq!(valid(r#""a\\b\\\uFFAZa""#.as_bytes()), false);
+        assert_eq!(valid(r#""a\\b\\\uFFA""#.as_bytes()), false);
+        assert_eq!(valid(r#""a\\b\\\uFFAZa""#.as_bytes()), false);
+        assert_eq!(valid(r#""#.as_bytes()), false);
+        assert_eq!(valid("[-]".as_bytes()), false);
+        assert_eq!(valid("[-.123]".as_bytes()), false);
     }
 
     #[test]
     fn xcover() {
         // code coverage
-        assert_eq!(valid(r#"{"hel\lo":"world"}"#), false);
-        assert_eq!(valid(r#"{"hello"  "#), false);
-        assert_eq!(valid(r#"{"hello"  : true "#), false);
-        assert_eq!(valid(r#"{"hello"  : true x"#), false);
-        assert_eq!(valid(r#"{"hello"  : true , "#), false);
-        assert_eq!(valid(r#"[  "#), false);
-        assert_eq!(valid(r#"[ true "#), false);
-        assert_eq!(valid(r#"[ true x "#), false);
-        assert_eq!(valid(r#"[ true , "#), false);
+        assert_eq!(valid(r#"{"hel\lo":"world"}"#.as_bytes()), false);
+        assert_eq!(valid(r#"{"hello"  "#.as_bytes()), false);
+        assert_eq!(valid(r#"{"hello"  : true "#.as_bytes()), false);
+        assert_eq!(valid(r#"{"hello"  : true x"#.as_bytes()), false);
+        assert_eq!(valid(r#"{"hello"  : true , "#.as_bytes()), false);
+        assert_eq!(valid(r#"[  "#.as_bytes()), false);
+        assert_eq!(valid(r#"[ true "#.as_bytes()), false);
+        assert_eq!(valid(r#"[ true x "#.as_bytes()), false);
+        assert_eq!(valid(r#"[ true , "#.as_bytes()), false);
 
-        assert_eq!(valid("[ \"hel\u{0}\" ]"), false);
-        assert_eq!(valid(r#"[ "hel\"#), false);
-        assert_eq!(valid(r#"[ "hel\u"#), false);
+        assert_eq!(valid("[ \"hel\u{0}\" ]".as_bytes()), false);
+        assert_eq!(valid(r#"[ "hel\"#.as_bytes()), false);
+        assert_eq!(valid(r#"[ "hel\u"#.as_bytes()), false);
 
-        assert_eq!(valid(r#"[ 123.x ]"#), false);
-        assert_eq!(valid(r#"[ 123.0e"#), false);
-        assert_eq!(valid(r#"[ 123.0e1f"#), false);
+        assert_eq!(valid(r#"[ 123.x ]"#.as_bytes()), false);
+        assert_eq!(valid(r#"[ 123.0e"#.as_bytes()), false);
+        assert_eq!(valid(r#"[ 123.0e1f"#.as_bytes()), false);
     }
 }

--- a/src/valid.rs
+++ b/src/valid.rs
@@ -263,12 +263,12 @@ fn valid_number(json: &[u8], mut i: usize) -> (bool, usize) {
     // sign
     if json[i] == b'-' {
         i += 1;
-		if i == json.len() {
-			return (false,i);
-		}
-		if json[i] < b'0' || json[i] > b'9' {
-			return (false, i);
-		}
+        if i == json.len() {
+            return (false, i);
+        }
+        if json[i] < b'0' || json[i] > b'9' {
+            return (false, i);
+        }
     }
     // int
     if i == json.len() {
@@ -333,7 +333,7 @@ fn valid_number(json: &[u8], mut i: usize) -> (bool, usize) {
             break;
         }
     }
-    return (true, i);
+    (true, i)
 }
 
 fn valid_true(json: &[u8], i: usize) -> (bool, usize) {


### PR DESCRIPTION
The main goal of this PR was to add a new function `gjson::get_bytes(...)` to compliment the `gjson::get(...)` preventing the need to convert to a string, but noticed a few other things while doing that so the highlights are:

- Added `gjson::get_bytes(...)` to compliment the `gjson::get(...)` [here](https://github.com/deankarn/gjson.rs/blob/support-bytes/src/lib.rs#L1025)
- Simplified and reduced size of `Value` by using `Cow` combining the `slice` and `owned` fields into one and deferring escaping strings until needed/used, see [here](https://github.com/deankarn/gjson.rs/blob/support-bytes/src/lib.rs#L82-L86)
- Converted a bunch of functions that accepted a `&str` and then immediately called `as_bytes()` on that string to accept a `&[u8]` directly which has reduced the need to convert between these types as well as returning `Vec<u8>` instead of `String` to help facilitate. See [here](https://github.com/deankarn/gjson.rs/blob/support-bytes/src/modifiers.rs#L84-L124) for example.
- Cleaned up some checks to be more idiomatic rust eg. `!data.is_empty()` vs `data.len() > 0` for readability.

These changes, for a project I'm using gjson in, benchmarked 5-10% faster in some situations when fetching values. 